### PR TITLE
Removed unittest2 imports

### DIFF
--- a/test_search.py
+++ b/test_search.py
@@ -39,7 +39,7 @@
 
 from selenium import selenium
 from vars import ConnectionParameters
-import unittest2 as unittest
+import unittest
 import re
 from addons_site import AddonsHomePage
 import sys

--- a/test_themes.py
+++ b/test_themes.py
@@ -39,7 +39,7 @@
 
 from selenium import selenium
 from vars import ConnectionParameters
-import unittest2 as unittest
+import unittest
 import re
 from addons_site import AddonsHomePage
 import sys


### PR DESCRIPTION
Several tests are not running because they import unittest2. We don't require unittest2, so I've just changed these to import unittest for now.
