### PR TITLE
Litmus 12037, 15392, 15393, 15394, and 15395

### DIFF
--- a/addons_site.py
+++ b/addons_site.py
@@ -283,7 +283,7 @@ class AddonsPersonasPage(AddonsHomePage):
     def click_start_exploring(self):
         self.selenium.click(self._start_exploring_locator)
         self.selenium.wait_for_page_to_load(self.timeout)
-        return AddonsPersonasPage(self.testsetup)
+        return AddonsPersonasBrowsePage(self.testsetup)
 
     @property
     def featured_personas_count(self):
@@ -376,6 +376,39 @@ class AddonsPersonasDetailPage(AddonsHomePage):
         locator = self.get_breadcrumb_item_locator(item)
         self.selenium.click(locator)
         self.selenium.wait_for_page_to_load(self.timeout)
+
+
+class AddonsPersonasBrowsePage(AddonsHomePage):
+    """
+    The personas browse page allows browsing the personas according to
+    some sort criteria (eg. top rated or most downloaded).
+
+    """
+
+    _selected_sort_by_locator = "css=#addon-list-options li.selected a"
+    _personas_grid_locator = "css=.featured.listing ul.personas-grid"
+
+    def __init__(self, testsetup):
+        Page.__init__(self, testsetup)
+
+    @property
+    def sort_key(self):
+        """ Returns the current value of the sort request parameter. """
+        url = self.get_url_current_page()
+        return re.search("[/][?]sort=(.+)[&]?", url).group(1)
+
+    @property
+    def sort_by(self):
+        """ Returns the label of the currently selected sort option. """
+        return self.selenium.get_text(self._selected_sort_by_locator)
+
+    @property
+    def is_the_current_page(self):
+        # This overrides the method in the Page super class.
+        if not (self.is_element_present(self._personas_grid_locator)):
+            self.record_error()
+            raise Exception('Expected the current page to be the personas browse page.')
+        return True
 
 
 class DiscoveryPane(Page):

--- a/test_personas.py
+++ b/test_personas.py
@@ -59,9 +59,10 @@ class TestPersonas:
         amo_personas_page = amo_home_page.click_personas()
         Assert.true(amo_personas_page.is_the_current_page)
         Assert.true(amo_personas_page.is_featured_addons_present)
-        upcoming_personas_page = amo_personas_page.click_start_exploring()
-        Assert.true(upcoming_personas_page.get_url_current_page().endswith("?sort=up-and-coming"))
-        Assert.true(upcoming_personas_page.is_text_present("Up & Coming Personas"))
+        browse_personas_page = amo_personas_page.click_start_exploring()
+        Assert.true(browse_personas_page.is_the_current_page)
+        Assert.equal("up-and-coming", browse_personas_page.sort_key)
+        Assert.equal("Up & Coming", browse_personas_page.sort_by)
 
     def test_page_title_for_personas_landing_page(self, testsetup):
         """ Test for Litmus 15391


### PR DESCRIPTION
Added tests for the following litmus test cases:

12037 - Verify Start Exploring link in the promo box
15392 - Check the 'Featured Personas' section
15393 - Check the 'Recently Added' section
15394 - Check the 'Most Popular' section 
15395 - Check the 'Top Rated' section
