### PR TITLE
Fix themes locator

### DIFF
--- a/addons_site.py
+++ b/addons_site.py
@@ -59,7 +59,7 @@ class AddonsHomePage(AddonsBasePage):
     _page_title = "Add-ons for Firefox"
 
     _download_count_locator = "css=div.stats > strong"
-    _themes_link_locator = "css=li#themes > a"
+    _themes_link_locator = "css=#themes > a"
     _personas_link_locator = "id=_t-9"
     _collections_link_locator = "id=_t-99"
 


### PR DESCRIPTION
This is a fix for the themes locator.  2 tests will still be failing:  test_that_themes_is_listed_as_a_category and test_that_clicking_on_theme_name_loads_its_detail_page
