### PR TITLE
Changed assertion to use contains method.

### DIFF
--- a/test_themes.py
+++ b/test_themes.py
@@ -124,7 +124,7 @@ class TestThemes:
         amo_themes_page = amo_home_page.click_themes()
         addon_name = amo_themes_page.addon_names[0]
         amo_theme_page = amo_themes_page.click_on_first_addon()
-        Assert.equal(addon_name, amo_theme_page.addon_title)
+        Assert.contains(addon_name, amo_theme_page.addon_title)
 
     def test_that_themes_page_has_correct_title(self, testsetup):
         """test for litmus 15340"""


### PR DESCRIPTION
The details page H1 tag now contains a span tag with the version number. The version number caused the Assert.equals to fail.

This solution uses the new Assert.contains method to check that the title that appeared on the homepage is contained inside the H1 tag on the details page.

Alternate (but more complex) solution would be to subtract the span text from the h1 text in python and assert upon that.
