### PR TITLE
Changed hardcoded assertion value

### DIFF
--- a/test_api_only.py
+++ b/test_api_only.py
@@ -34,4 +34,4 @@ class TestAPIOnlyTests:
     def test_firebug_version_number(self, testsetup):
         """Testcase for Litmus 15317"""
         addon_xml = AddOnsAPI(testsetup)
-        Assert.equal("1.7.3", addon_xml.get_addon_version_number("Firebug"))
+        Assert.equal("1.8.0", addon_xml.get_addon_version_number("Firebug"))


### PR DESCRIPTION
Changed hardcoded version number to reflect that found on the addon's detail webpage:
https://addons.allizom.org/en-US/firefox/addon/firebug/

This test is compromised by the hardcoded value. It will fail again in the future. We should rethink this test or obtain the version from a different source.
