### PR TITLE
Switch from https://addons.allizom.org (in SJC) -> https://addons-dev.allizom.org (in PHX)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -124,7 +124,7 @@ def pytest_addoption(parser):
     parser.addoption("--base-url",
                      action="store",
                      dest="base_url",
-                     default="http://addons.allizom.org",
+                     default="http://addons-dev.allizom.org",
                      help="base URL for the application under test")
     parser.addoption("--timeout",
                      action="store",


### PR DESCRIPTION
Switching to the new https://addons-dev.allizom.org dev/trunk staging server.  I talked about this with Jeff and Jeremy, and the time is now, to move over.
