### PR TITLE
Removed TestDiscoveryPane.test_that_addons_count_are_equal_between_amo_and_discovery

### DIFF
--- a/addons_site.py
+++ b/addons_site.py
@@ -58,7 +58,6 @@ class AddonsHomePage(AddonsBasePage):
 
     _page_title = "Add-ons for Firefox"
 
-    _download_count_locator = "css=div.stats > strong"
     _themes_link_locator = "css=#themes > a"
     _personas_link_locator = "css=#personas > a"
     _collections_link_locator = "css=#collections > a"
@@ -94,10 +93,6 @@ class AddonsHomePage(AddonsBasePage):
         self.selenium.open("%s/addon/%s" % (self.site_version, id))
         self.selenium.wait_for_page_to_load(self.timeout)
         return AddonsDetailsPage(self.testsetup, id)
-
-    @property
-    def download_count(self):
-        return self.selenium.get_text(self._download_count_locator)
 
     def _extract_iso_dates(self, xpath_locator, date_format, count):
         """

--- a/test_discovery_page.py
+++ b/test_discovery_page.py
@@ -82,17 +82,6 @@ class TestDiscoveryPane:
         download_count_regex = "Add-ons downloaded: (.+)"
         Assert.true(re.search(download_count_regex, discovery_pane.download_count) != None)
 
-    def test_that_addons_count_are_equal_between_amo_and_discovery(self, testsetup):
-        """ TestCase for Litmus 15066 """
-        amo_home_page = AddonsHomePage(testsetup)
-        amo_download_count = amo_home_page.download_count.replace(",", "")
-
-        discovery_pane = DiscoveryPane(testsetup, self.basepath)
-        discovery_download_count_text = discovery_pane.download_count
-        download_count = re.search("Add-ons downloaded: (.+)", discovery_download_count_text).group(1)
-        download_count = download_count.replace(",", "")
-        Assert.equal(amo_download_count, download_count)
-
     @xfail(reason="Disabled until bug 674374 is fixed.")
     def test_that_featured_personas_is_present_and_has_5_item(self, testsetup):
         """ TestCase for Litmus 15079, 15080 """


### PR DESCRIPTION
Removed TestDiscoveryPane.test_that_addons_count_are_equal_between_amo_and_discovery
In the new AMO homepage, the addons download count(the stats)
is no longer shown, so there is no need for the test any more.
