### PR TITLE
Revving the version # of Firebug to be 1.8.1, from 1.8.0.  See https://addons-dev.allizom.org/en-US/firefox/addon/firebug/

### DIFF
--- a/test_api_only.py
+++ b/test_api_only.py
@@ -34,4 +34,4 @@ class TestAPIOnlyTests:
     def test_firebug_version_number(self, mozwebqa):
         """Testcase for Litmus 15317"""
         addon_xml = AddOnsAPI(mozwebqa)
-        Assert.equal("1.8.0", addon_xml.get_addon_version_number("Firebug"))
+        Assert.equal("1.8.1", addon_xml.get_addon_version_number("Firebug"))


### PR DESCRIPTION
Revving the version # of Firebug to be 1.8.1, from 1.8.0.  See https://addons-dev.allizom.org/en-US/firefox/addon/firebug/
