### PR TITLE
remove open and added click to fix the awkward statement

### DIFF
--- a/addons_site.py
+++ b/addons_site.py
@@ -370,7 +370,8 @@ class AddonsDetailsPage(AddonsBasePage):
         return self.selenium.get_attribute("%s@href" % self._website_locator)
 
     def click_website_link(self):
-        self.selenium.open(self.website)
+        self.selenium.click(self._website_locator)
+        self.selenium.wait_for_page_to_load(self.timeout)
 
     @property
     def support_url(self):


### PR DESCRIPTION
the click_website_link method contains a self.selenium.open statement.
This statement is awkward in the method context.
Updated the method with a self.selenium click statement 
