### PR TITLE
Revving Firebug's version in the API tests, to match the version in addons-dev

### DIFF
--- a/test_api_only.py
+++ b/test_api_only.py
@@ -71,4 +71,4 @@ class TestAPIOnlyTests:
     def test_firebug_version_number(self, mozwebqa):
         """Testcase for Litmus 15317"""
         addon_xml = AddOnsAPI(mozwebqa)
-        Assert.equal("1.8.1", addon_xml.get_addon_version_number("Firebug"))
+        Assert.equal("1.8.2", addon_xml.get_addon_version_number("Firebug"))


### PR DESCRIPTION
Revving Firebug's version in the API tests, to match the version in addons-dev.allizom.org
