### PR TITLE
fixed addon name open link

### DIFF
--- a/addons_details_page.py
+++ b/addons_details_page.py
@@ -106,7 +106,8 @@ class AddonsDetailsPage(AddonsBasePage):
         #formats name for url
         AddonsBasePage.__init__(self, testsetup)
         if (addon_name != None):
-            self.addon_name = re.sub(r'[^\w-]', '', addon_name).lower()
+            self.addon_name = addon_name.replace(" ", "-")
+            self.addon_name = re.sub(r'[^A-Za-z0-9\-]', '', self.addon_name).lower()
             self.addon_name = self.addon_name[:27]
             self.selenium.open("%s/addon/%s" % (self.site_version, self.addon_name))
             self._wait_for_reviews_and_other_addons_by_author_to_load()


### PR DESCRIPTION
test_that_external_link_leads_to_addon_website is failing because a hyphen is inserted between the two words adblock-plus when the url is created. Currently the test is trying to open 
https://addons-dev.allizom.org/en-US/firefox/addon/adblockplus/ but the url is really
https://addons-dev.allizom.org/en-US/firefox/addon/adblock-plus/

https://www.pivotaltracker.com/story/show/19261717
