### PR TITLE
Remove duplicate tests from test_homepage.py

### DIFF
--- a/base_page.py
+++ b/base_page.py
@@ -216,10 +216,6 @@ class BasePage(Page):
         def is_thunderbird_visible(self):
             return self.is_element_present(self._app_thunderbird)
 
-        @property
-        def other_applications_tooltip(self):
-            return self.selenium.get_attribute("%s@title" % self._other_applications_locator)
-
         def search_for(self, search_term):
             self.selenium.type(self._search_textbox_locator, search_term)
             self.selenium.click(self._search_button_locator)

--- a/test_homepage.py
+++ b/test_homepage.py
@@ -46,14 +46,6 @@ import pytest
 
 class TestHomePage:
 
-    def test_that_verifies_the_tooltip_for_Other_Applications(self, mozwebqa):
-        """
-        Litmus 22925
-        https://litmus.mozilla.org/show_test.cgi?id=22925
-        """
-        home_page = HomePage(mozwebqa)
-        Assert.equal(home_page.header.other_applications_tooltip, 'Find add-ons for other applications')
-
     def test_that_checks_the_most_popular_section_exists(self, mozwebqa):
         """
         Litmus 25807
@@ -124,7 +116,7 @@ class TestHomePage:
 
     def test_that_other_applications_link_has_tooltip(self, mozwebqa):
         """ Litmus 22925
-            https://litmus.mozilla.org/show_test.cgi?id=29698 """
+            https://litmus.mozilla.org/show_test.cgi?id=22925 """
         home_page = HomePage(mozwebqa)
         tooltip = home_page.get_title_of_link('Other applications')
         Assert.equal(tooltip, 'Find add-ons for other applications')


### PR DESCRIPTION
In test_homepage.py there are two test for the same Litmus test 22925:
test_that_verifies_the_tooltip_for_Other_Applications()
and test_that_other_applications_link_has_tooltip.
