### PR TITLE
Removed test_that_counters_show_the_same_number_of_themes() from test_the

### DIFF
--- a/test_themes.py
+++ b/test_themes.py
@@ -157,12 +157,6 @@ class TestThemes:
         expected_breadcrumb = "Add-ons for Firefox Themes %s" % selected_category
         Assert.equal(expected_breadcrumb, amo_category_page.breadcrumb)
 
-    def test_that_counters_show_the_same_number_of_themes(self, mozwebqa):
-        """test for litmus 15345"""
-        home_page = HomePage(mozwebqa)
-        themes_page = home_page.click_themes()
-        Assert.equal(themes_page.top_counter, themes_page.bottom_counter)
-
     def test_that_themes_categories_are_listed_on_left_hand_side(self, mozwebqa):
         """ test for litmus 15342"""
         home_page = HomePage(mozwebqa)

--- a/themes_page.py
+++ b/themes_page.py
@@ -67,8 +67,6 @@ class ThemesPage(BasePage):
     _category_locator = "css=#c-30 > a"
     _categories_locator = "css=#side-categories li"
     _category_link_locator = _categories_locator + ":nth-of-type(%s) a"
-    _top_counter_locator = "css=div.primary>header b"
-    _bottom_counter_locator = "css=div.num-results > strong:nth(2)"
 
     def __init__(self, testsetup):
         BasePage.__init__(self, testsetup)
@@ -137,14 +135,6 @@ class ThemesPage(BasePage):
         ratings_locator = self._addons_rating_locator
         ratings = self._extract_integers(ratings_locator, pattern, self.addon_count)
         return ratings
-
-    @property
-    def top_counter(self):
-        return self.selenium.get_text(self._top_counter_locator)
-
-    @property
-    def bottom_counter(self):
-        return self.selenium.get_text(self._bottom_counter_locator)
 
 
 class ThemePage(BasePage):


### PR DESCRIPTION
Removed test_that_counters_show_the_same_number_of_themes() from test_themes.py
The counter under heading Themes was removed from the new themes page, so
we don't need the test anymore. I talked to Krupa and she agrees.
