### PR TITLE
Updated Test test_that_version_information_is_displayed for Litmus 25721

### DIFF
--- a/pages/details.py
+++ b/pages/details.py
@@ -531,7 +531,7 @@ class Details(Base):
     def click_version_info_link(self):
         self.selenium.click(self._info_link_locator)
 
-    def expand_version_information_section(self):
+    def click_version_information_header(self):
         self.selenium.click("%s > a" % self._version_information_heading_locator)
 
     def click_devs_comments_title(self):

--- a/tests/test_details_page.py
+++ b/tests/test_details_page.py
@@ -105,7 +105,7 @@ class TestDetails:
         Updated for Litmus 25721
         https://litmus.mozilla.org/show_test.cgi?searchType=by_id&id=25721
         """
-        details_page.expand_version_information_section()
+        details_page.click_version_information_header()
         Assert.true(details_page.is_version_information_section_expanded)
         Assert.true(details_page.is_source_code_license_information_visible)
         Assert.true(details_page.is_whats_this_license_visible)


### PR DESCRIPTION
Updated Test test_that_version_information_is_displayed for 
https://litmus.mozilla.org/show_test.cgi?searchType=by_id&id=25721
#25721 - Verify "Version Information" section
