### PR TITLE
Updated the regex that checks the experimental version of Firebug

### DIFF
--- a/tests/test_details_page.py
+++ b/tests/test_details_page.py
@@ -415,7 +415,7 @@ class TestDetails:
         Assert.true(details_page.is_development_channel_install_button_visible)
 
         # Verify experimental version (beta or pre)
-        Assert.not_none(re.match('Version %s(b|a|rc)[0-9]:' % details_page.version_number, details_page.beta_version))
+        Assert.not_none(re.match('Version \d\.\d.\d(b|a|rc)[0-9]:', details_page.beta_version))
 
     def test_that_license_link_works(self, mozwebqa):
         """


### PR DESCRIPTION
Now, the next version can have any number, not just the numbers of
the current version
Ex: current version: 1.8.4
    beta version: 1.9.0b3
