### PR TITLE
Remove link to plugins (fixes failing test)

### DIFF
--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -62,7 +62,7 @@ class TestHome:
                                      "OS Integration", "Retro", "Sports"],
                 "Collections":      ["Featured", "Most Followers", "Newest", "Collections I've Made", "Collections I'm Following",
                                      "My Favorite Add-ons"],
-                u"More\u2026":      ["Add-ons for Mobile", "Dictionaries & Language Packs", "Plugins", "Search Tools", "Developer Hub"]
+                u"More\u2026":      ["Add-ons for Mobile", "Dictionaries & Language Packs", "Search Tools", "Developer Hub"]
                 }
 
     @nondestructive


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=686970; the Plugins
page and the link to it are now gone on -dev.
