### PR TITLE
Add contibutor link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Selenium Tests for addons.mozilla.org (amo)
 
 Thank you for checking out Mozilla's Addon-Tests test suite. Mozilla and the Mozwebqa team are grateful for the help and hard work of many contributors like yourself.
 The following contributors have submitted pull requests to Addon-Tests:
+
 https://github.com/mozilla/Addon-Tests/contributors
 
 Getting involved as a contributor


### PR DESCRIPTION
Represent the contributors in the readme.md

Please scrutinise this one closely as it may become the model for other Readme files.
