### PR TITLE
Check that contribute button doesn't show up on mobile details page.

### DIFF
--- a/pages/mobile/details.py
+++ b/pages/mobile/details.py
@@ -14,7 +14,7 @@ from pages.mobile.base import Base
 class Details(Base):
 
     _title_locator = (By.CSS_SELECTOR, 'div.infobox > h3')
-    _buttons_locator = (By.CSS_SELECTOR, '.button')
+    _contribute_button_locator = (By.XPATH, "//a[contains(.,'Contribute')]")
 
     def __init__(self, testsetup, addon_name=None):
         #formats name for url
@@ -34,5 +34,5 @@ class Details(Base):
         return self.selenium.find_element(*self._title_locator).text
 
     @property
-    def buttons(self):
-        return [element.text for element in self.selenium.find_elements(*self._buttons_locator)]
+    def is_contribute_button_present(self):
+        return self.is_element_present(*self._contribute_button_locator)

--- a/tests/mobile/test_details.py
+++ b/tests/mobile/test_details.py
@@ -16,5 +16,4 @@ class TestDetails:
     def test_that_contribute_button_is_not_present_on_the_mobile_page(self, mozwebqa):
         details_page = Details(mozwebqa, 'Adblock Plus')
         Assert.true(details_page.is_the_current_page)
-        Assert.false('Contribute' in details_page.buttons)
-
+        Assert.false(details_page.is_contribute_button_present)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/24955445
STR:
1. From the mobile site, go to the details page for Adblock Plus.
2. In the details page, make sure we don't show Contribute button.
