### PR TITLE
Fix for test_the_applications_listed_in_other_applications()

### DIFF
--- a/tests/desktop/test_layout.py
+++ b/tests/desktop/test_layout.py
@@ -87,8 +87,7 @@ class TestAmoLayout:
         expected_apps = [
             "Thunderbird",
             "Mobile",
-            "SeaMonkey",
-            "Sunbird"]
+            "SeaMonkey"]
         home_page = Home(mozwebqa)
 
         for app in expected_apps:


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=617989, Sunbird
is no longer supported.
