### PR TITLE
Fixes unicode issues and quotes

### DIFF
--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -438,9 +438,9 @@ class TestDetails:
         details_page = Details(mozwebqa, "MemChaser")
         Assert.equal(details_page.version_information_heading, "Version Information")
         details_page.click_version_information_header()
-        Assert.equal("What's this?", unicode(details_page.license_faq.text) )
+        Assert.equal("What's this?", unicode(details_page.license_faq.text))
         details_page.license_faq.click()
-        Assert.equal("Frequently Asked Questions" , details_page.freq_asked_question)
+        Assert.equal("Frequently Asked Questions", details_page.freq_asked_question)
 
     @pytest.mark.nondestructive
     def test_view_the_source_in_the_version_information(self, mozwebqa):


### PR DESCRIPTION
Asking Victor to review this pull request since it fixes some stuff in his tests.  
1. Text needed to be converted to unicode for the asserts.  This is the failure I saw yesterday and why it's failing in Jenkins.
2. Single quotes are for text that is not language such as an url.  Double quotes are for language such as "What's this" or "Hello."  If it's actual words and phrases, double quotes apply.

Note to self:  Will keep the wet noodle closer for better code review lashings.
