### PR TITLE
Fix for TestDetails.test_addon_information_in_flyout_matches_to_its_deta...

### DIFF
--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -192,6 +192,7 @@ class Home(Base):
         _author_locator = (By.CSS_SELECTOR, 'div.addon > div.more > div.byline > a')
         _number_of_users_locator = (By.CSS_SELECTOR, 'div.more > div.vitals > div.vital > span.adu')
         _summary_locator = (By.CSS_SELECTOR, 'div.addon > div.more > .addon-summary')
+        _link_locator = (By.CSS_SELECTOR, 'div.addon > .summary')
 
         def __init__(self, testsetup, web_element):
             Page.__init__(self, testsetup)
@@ -226,7 +227,7 @@ class Home(Base):
             return self._root_element.find_element(*self._summary_locator).text
 
         def click_on_addon(self):
-            self._root_element.click()
+            self._root_element.find_element(*self._link_locator).click()
             from pages.desktop.details import Details
             return Details(self.testsetup)
 

--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -421,7 +421,6 @@ class TestDetails:
         Assert.true(details_page.is_reviews_section_visible)
         Assert.true(details_page.is_reviews_section_in_view)
 
-    @pytest.mark.xfail(reason="needs a wait https://www.pivotaltracker.com/story/show/27724123")
     @pytest.mark.nondestructive
     @pytest.mark.native
     def test_addon_information_in_flyout_matches_to_its_details_page(self, mozwebqa):
@@ -439,6 +438,7 @@ class TestDetails:
         expected_number_of_users = first_addon.number_of_users
 
         details_page = first_addon.click_on_addon()
+        Assert.true(details_page.is_the_current_page)
 
         Assert.equal(details_page.rating, expected_star_rating)
         Assert.equal(details_page.total_review_count, expected_total_review_count)


### PR DESCRIPTION
...ils_page

The problem was with first_addon.click_on_addon(). The click wasn't executed
because some locators changed.

Also removed the @xfail mark.
