### PR TITLE
add wait for page title to make sure url is completely loaded

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -38,6 +38,7 @@ class Page(object):
         return True
 
     def get_url_current_page(self):
+        WebDriverWait(self.selenium, 10).until(lambda s: self.selenium.title)
         return self.selenium.current_url
 
     def is_element_present(self, *locator):


### PR DESCRIPTION
It looks like lots of the failing tests are because the url isn't loading quickly enough for webdriver.  Adding this wait for the page title might help some of the other tests that are failing when checking an url.
