### PR TITLE
add firefox7 mark to paypal tests

### DIFF
--- a/tests/desktop/test_paypal.py
+++ b/tests/desktop/test_paypal.py
@@ -21,7 +21,7 @@ class TestPaypal:
 
     addon_name = 'Firebug'
 
-    @pytest.mark.firefox7
+    @pytest.mark.deprecated_firefox
     @pytest.mark.login
     def test_that_user_can_contribute_to_an_addon(self, mozwebqa):
         """Test that checks the Contribute button for an addon using PayPal."""
@@ -45,7 +45,7 @@ class TestPaypal:
         payment_popup.close_paypal_popup()
         Assert.true(addon_page.is_the_current_page)
 
-    @pytest.mark.firefox7
+    @pytest.mark.deprecated_firefox
     def test_that_user_can_make_a_contribution_without_logging_into_amo(self, mozwebqa):
         """Test that checks if the user is able to make a contribution without logging in to AMO."""
         addon_page = Details(mozwebqa, self.addon_name)


### PR DESCRIPTION
Instead of a "paypal" mark, I added a mark for firefox7 because there is one test that only opens the paypal window and it is still passing on FF11.  Once this is merged I can create a job for Firefox 7.
