### PR TITLE
Prepare test_that_carousel_works for production

### DIFF
--- a/tests/desktop/test_discovery_page.py
+++ b/tests/desktop/test_discovery_page.py
@@ -95,6 +95,7 @@ class TestDiscoveryPane:
         Assert.true(home_page.is_the_current_page)
         Assert.false(home_page.header.is_user_logged_in)
 
+    @pytest.mark.smoke
     @pytest.mark.native
     @pytest.mark.nondestructive
     def test_that_carousel_works(self, mozwebqa):


### PR DESCRIPTION
Test this on prod and stage 

PS: For this to work on prod we have to add the correct api url as a command line argument:
--apibaseurl=https://services.addons.mozilla.org/
this argument is added in conftest.py

On stage this argument has the default value : https://addons-dev.allizom.org 
