### PR TITLE
xfail authors test

### DIFF
--- a/tests/desktop/test_homepage.py
+++ b/tests/desktop/test_homepage.py
@@ -265,6 +265,7 @@ class TestHome:
             Assert.equal(len(up_and_coming_island.addons), 6)
             up_and_coming_island.pager.prev()
 
+    @pytest.mark.xfail(reason="very flaky, see refactor task: https://www.pivotaltracker.com/story/show/28494843")
     @pytest.mark.nondestructive
     def test_addons_author_link(self, mozwebqa):
         """


### PR DESCRIPTION
This test is too flaky to be useful: https://skitch.com/e-marlenac/8ijq4/history-for-test-addons-author-link-jenkins
Xfail contains a tracker story to improve it.  Leaving it xfailed in the meantime.
