### PR TITLE
Remove xfails to increase test coverage

### DIFF
--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -181,7 +181,6 @@ class TestDetails:
         Assert.false(image_viewer.is_visible)
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="waiting for the release of selenium 2.21")
     def test_navigation_buttons_for_image_viewer(self, mozwebqa):
         """
         Test for Litmus 4846.

--- a/tests/desktop/test_homepage.py
+++ b/tests/desktop/test_homepage.py
@@ -148,7 +148,6 @@ class TestHome:
 
     @pytest.mark.native
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="waiting for the release of selenium 2.21")
     def test_that_items_menu_fly_out_while_hovering(self, mozwebqa):
         """
         Test for Litmus 25754.

--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -244,7 +244,6 @@ class TestSearch:
         Assert.greater_equal(result_count, search_page.filter.results_count)
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="Bugzilla 722647")
     def test_that_search_results_return_20_results_per_page(self, mozwebqa):
         """
         Test for Litmus 17346.

--- a/tests/desktop/test_statistics.py
+++ b/tests/desktop/test_statistics.py
@@ -12,7 +12,6 @@ from pages.desktop.details import Details
 class TestStatistics:
 
     @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason="https://bugzilla.mozilla.org/show_bug.cgi?id=742108")
     def test_that_verifies_the_url_of_the_statistics_page(self, mozwebqa):
         """ Test for Litmus 25710
         https://litmus.mozilla.org/show_test.cgi?searchType=by_id&id=25710


### PR DESCRIPTION
Remove 2 webdriver-related xfails that were consistently xpassing.
Remove 2 for which the bugs had been fixed.
