### PR TITLE
Explicit wait for stats page to load

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -139,7 +139,9 @@ class Details(Base):
     def click_view_statistics(self):
         self.selenium.find_element(*self._daily_users_link_locator).click()
         from pages.desktop.statistics import Statistics
-        return Statistics(self.testsetup)
+        stats_page = Statistics(self.testsetup)
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: stats_page.is_chart_loaded) 
+        return stats_page
 
     @property
     def daily_users_number(self):

--- a/pages/desktop/statistics.py
+++ b/pages/desktop/statistics.py
@@ -15,10 +15,16 @@ class Statistics(Base):
     _title_locator = (By.CSS_SELECTOR, '.addon')
     _total_downloads_locator = (By.CSS_SELECTOR, '.island.two-up div:nth-child(1) a')
     _usage_locator = (By.CSS_SELECTOR, '.island.two-up div:nth-child(2) a')
+    _chart_locator = (By.CSS_SELECTOR, '#head-chart > div')
+    _no_data_locator = (By.CSS_SELECTOR, 'div.no-data-overlay')
 
     @property
     def _page_title(self):
         return "%s :: Statistics Dashboard :: Add-ons for Firefox" % self.addon_name
+
+    @property
+    def is_chart_loaded(self):
+        return self.is_element_present(*self._chart_locator) or self.is_element_visible(*self._no_data_locator)
 
     @property
     def addon_name(self):


### PR DESCRIPTION
Explicit wait for stats page to load. Using the chart having loaded as indicator of the page load state.
