### PR TITLE
xfail test_that_external_link_leads_to_addon_website

### DIFF
--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -110,6 +110,7 @@ class TestDetails:
         Assert.true(len(details_page.part_of_collections) > 0)
 
     @pytest.mark.nondestructive
+    @pytest.mark.xfail(reason="Being fixed in https://github.com/mozilla/Addon-Tests/pull/477")
     def test_that_external_link_leads_to_addon_website(self, mozwebqa):
         """
         Test for Litmus 11809.


### PR DESCRIPTION
Being taken care of in https://github.com/mozilla/Addon-Tests/pull/477; when that finally lands, we'll remove this xfail, but it shouldn't be failing the build.
