### PR TITLE
xfaild TestHome.test_the_name_of_each_site_navigation_menu_in_the_header

### DIFF
--- a/tests/desktop/test_homepage.py
+++ b/tests/desktop/test_homepage.py
@@ -223,6 +223,7 @@ class TestHome:
     @pytest.mark.native
     @pytest.mark.nondestructive
     @pytest.mark.litmus([25745, 25747, 25749, 25751, 25754, 25756, 25758, 25760, 25763, 25764])
+    @pytest.mark.xfail(reason = 'Disabled until the issue causing the fail is found and fixed.')
     def test_the_name_of_each_site_navigation_menu_in_the_header(self, mozwebqa):
         home_page = Home(mozwebqa)
 
@@ -272,7 +273,7 @@ class TestHome:
             Assert.equal(len(up_and_coming_island.addons), 6)
             up_and_coming_island.pager.prev()
 
-    @pytest.mark.xfail(reason="very flaky, see refactor task: https://www.pivotaltracker.com/story/show/28494843")
+    @pytest.mark.xfail(reason = "very flaky, see refactor task: https://www.pivotaltracker.com/story/show/28494843")
     @pytest.mark.nondestructive
     def test_addons_author_link(self, mozwebqa):
         """


### PR DESCRIPTION
I was not able to reproduce this locally. The only case in which the test fails is when the mouse is moved around the navigation menu during the test run, but this should not occur in our grid. 

This needs further investigation. I'm xfailing it until I find a fix.
