### PR TITLE
Remove test for checking whether extensions are sorted correctly by featured

### DIFF
--- a/tests/desktop/test_extensions.py
+++ b/tests/desktop/test_extensions.py
@@ -83,22 +83,6 @@ class TestExtensions:
 
     @pytest.mark.native
     @pytest.mark.nondestructive
-    def test_that_checks_if_the_extensions_are_sorted_by_featured(self, mozwebqa):
-        """
-        Test for Litmus 29713
-        https://litmus.mozilla.org/show_test.cgi?searchType=by_id&id=29713
-        """
-        home_page = Home(mozwebqa)
-        featured_extensions_page = home_page.header.site_navigation_menu("Extensions").click()
-        featured_extensions_page.sorter.sort_by('most users')
-        featured_extensions_page.sorter.sort_by('featured')
-
-        Assert.contains("sort=featured", featured_extensions_page.get_url_current_page())
-        for extension in featured_extensions_page.extensions:
-            Assert.equal("FEATURED", extension.featured)
-
-    @pytest.mark.native
-    @pytest.mark.nondestructive
     def test_that_checks_if_the_extensions_are_sorted_by_top_rated(self, mozwebqa):
         """
         Test for Litmus 29717


### PR DESCRIPTION
This is covered by AMO's unit tests, here: https://github.com/mozilla/zamboni/blob/master/apps/browse/tests.py#L158.  Thanks to @cvan.

@krupa, do you approve?  It's failing, currently (and can be problematic).
