### PR TITLE
Added an explicit wait to address intermittent error shown at http://pastie.org/4279628

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -107,6 +107,8 @@ class Details(Base):
 
     @property
     def title(self):
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: self.is_element_visible(*self._title_locator))
         base = self.selenium.find_element(*self._title_locator).text
         '''base = "firebug 1.8.9" we will have to remove version number for it'''
         return base.replace(self.version_number, '').replace(self.no_restart, '').strip()


### PR DESCRIPTION
Looking at the code, this wait really doesn't seem necessary, but the failure referenced above shows that there is some sort of problem with a wait in this situation. I originally tried adding it into the **init** method of the page object, but that caused problems with the test at https://github.com/mozilla/Addon-Tests/blob/master/tests/desktop/test_details_page_against_xml.py#L182 because it instantiates the page object without navigating to a page first, causing the wait to timeout.
