### PR TITLE
Moved the WebDriverWait into __init__ where I originally wanted it

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -100,6 +100,8 @@ class Details(Base):
             self.addon_name = re.sub(r'[^A-Za-z0-9\-]', '', self.addon_name).lower()
             self.addon_name = self.addon_name[:27]
             self.selenium.get("%s/addon/%s" % (self.base_url, self.addon_name))
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: self.is_element_visible(*self._title_locator))
 
     @property
     def _page_title(self):
@@ -107,8 +109,6 @@ class Details(Base):
 
     @property
     def title(self):
-        WebDriverWait(self.selenium, self.timeout).until(
-            lambda s: self.is_element_visible(*self._title_locator))
         base = self.selenium.find_element(*self._title_locator).text
         '''base = "firebug 1.8.9" we will have to remove version number for it'''
         return base.replace(self.version_number, '').replace(self.no_restart, '').strip()

--- a/tests/desktop/test_details_page_against_xml.py
+++ b/tests/desktop/test_details_page_against_xml.py
@@ -187,7 +187,7 @@ class TestDetailsAgainstXML:
         learn_more_url = addons_xml.get_learn_more_url(self.firebug)
 
         #browser
-        details_page = Details(mozwebqa)
+        details_page = Details(mozwebqa, self.firebug)
         details_page.get_url(learn_more_url)
 
         Assert.contains(self.firebug, details_page.page_title)


### PR DESCRIPTION
Fixed a test that was instantiating a page object without navigating to a page, which allowed me to move the code.

This is a follow-up to the pull request at https://github.com/mozilla/Addon-Tests/pull/529, which has already been merged.
