### PR TITLE
Add wait for lightbox to be visible

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -412,8 +412,10 @@ class Details(Base):
         def click_image(self, image_no=0):
             images = self.selenium.find_elements(*self._image_locator)
             images[image_no].find_element(*self._link_locator).click()
+
             from pages.desktop.regions.image_viewer import ImageViewer
             image_viewer = ImageViewer(self.testsetup)
+            WebDriverWait(self.selenium, 10).until(lambda s: image_viewer.is_visible)
             return image_viewer
 
         def image_title(self, image_no):


### PR DESCRIPTION
As this is an ajax function I added an explicit wait for the element to be visible.
Couldn't replicate it locally but the visible state we are waiting for is not complex and should stabilise the test_navigation_buttons_for_image_viewer test.
