### PR TITLE
Fix for test_api_only.TestAPIOnlyTests.test_firebug_version_number

### DIFF
--- a/tests/desktop/test_api_only.py
+++ b/tests/desktop/test_api_only.py
@@ -47,7 +47,7 @@ class TestAPIOnlyTests:
     def test_firebug_version_number(self, mozwebqa):
         """Test for Litmus 15317."""
         addon_xml = AddOnsAPI(mozwebqa)
-        Assert.equal("1.10.0", addon_xml.get_addon_version_number("Firebug"))
+        Assert.equal("1.10.3", addon_xml.get_addon_version_number("Firebug"))
 
     @pytest.mark.nondestructive
     def test_that_firebug_status_id_is_4_and_fully_reviewed(self, mozwebqa):


### PR DESCRIPTION
A new firebug version has been released. Updated the test accordingly.
