### PR TITLE
Remove xfail from test_paypal.py for:

### DIFF
--- a/tests/desktop/test_paypal.py
+++ b/tests/desktop/test_paypal.py
@@ -58,7 +58,6 @@ class TestPaypal:
         payment_popup.close_paypal_popup()
         Assert.true(addon_page.is_the_current_page)
 
-    @pytest.mark.xfail(reason="Bug 802142 - 'Make contribution' to an add-on doesn't load the PayPal frame and freezes page")
     @pytest.mark.smoke
     @pytest.mark.nondestructive
     def test_that_make_contribution_button_is_clickable_and_loads_paypal_frame_while_user_is_logged_out(self, mozwebqa):
@@ -73,7 +72,6 @@ class TestPaypal:
         contribution_snippet.click_make_contribution_button()
         Assert.true(addon_page.is_paypal_login_dialog_visible)
 
-    @pytest.mark.xfail(reason="Bug 802142 - 'Make contribution' to an add-on doesn't load the PayPal frame and freezes page")
     @pytest.mark.smoke
     @pytest.mark.nondestructive
     @pytest.mark.login


### PR DESCRIPTION
-test_that_make_contribution_button_is_clickable_and_loads_paypal_frame_while_user_is_logged_out
-that_make_contribution_button_is_clickable_and_loads_paypal_frame_while_user_is_logged_in

Tests pass both on Jenkins and locally on my grid.
