### PR TITLE
Fix for TestHome.test_addons_author_link

### DIFF
--- a/pages/desktop/home.py
+++ b/pages/desktop/home.py
@@ -38,7 +38,7 @@ class Home(Base):
 
     _featured_extensions_title_locator = (By.CSS_SELECTOR, '#featured-extensions > h2')
     _featured_extensions_see_all_locator = (By.CSS_SELECTOR, '#featured-extensions > h2 > a')
-    _featured_extensions_elements_locator = (By.CSS_SELECTOR, '#featured-extensions section:nth-child(1) > li')
+    _featured_extensions_elements_locator = (By.CSS_SELECTOR, '#featured-extensions section:nth-child(1) > li > div')
 
     _extensions_menu_link = (By.CSS_SELECTOR, "#extensions > a")
 


### PR DESCRIPTION
The test fails sporadically in Jenkins and it contains native events.
I updated the locator since I suspect that the fails are
caused by a hover issues.
