### PR TITLE
Xfail Paypal tests because of https://bugzilla.mozilla.org/show_bug.cgi?id=820407

### DIFF
--- a/tests/desktop/test_paypal.py
+++ b/tests/desktop/test_paypal.py
@@ -13,6 +13,8 @@ from pages.desktop.home import Home
 from pages.desktop.details import Details
 
 
+@pytest.mark.xfail(reason="Bug 820407 - [dev]'Make Contribution' button doesn't load PayPal frame")
+# https://bugzilla.mozilla.org/show_bug.cgi?id=820407
 class TestPaypal:
 
     addon_name = 'Firebug'


### PR DESCRIPTION
This should fix the one fail on amo.dev.mac and 4 fails on amo.dev
