### PR TITLE
Added wait for development channel content

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -79,7 +79,7 @@ class Details(Base):
     _add_to_collection_widget_login_link_locator = (By.CSS_SELECTOR, "div.collection-add-login p:nth-child(3) > a")
     _add_to_favorites_widget_locator = (By.CSS_SELECTOR, 'div.widgets > a.favorite')
 
-    _development_channel_content_locator = (By.CSS_SELECTOR, '.content>p')
+    _development_channel_content_locator = (By.CSS_SELECTOR, '.content > p')
     _development_channel_locator = (By.CSS_SELECTOR, "#beta-channel")
     _development_channel_toggle = (By.CSS_SELECTOR, '#beta-channel a.toggle')
     _development_channel_install_button_locator = (By.CSS_SELECTOR, '#beta-channel p.install-button a.button.caution')


### PR DESCRIPTION
This is for http://qa-selenium.mv.mozilla.com:8080/view/AMO/job/amo.dev.mac.saucelabs/lastCompletedBuild/testReport/tests.desktop.test_details_page/TestDetails/test_the_development_channel_section/
The fail was reproducible locally
With this wait I cannot reproduce it anymore
