### PR TITLE
Change wait logic for expanded section to use class instead of visibility

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -521,8 +521,10 @@ class Details(Base):
         return self.selenium.find_element(*self._development_channel_title_locator).text
 
     def click_development_channel(self):
+        expander = self.selenium.find_element(*self._development_channel_toggle)
+        expander_saved_class = expander.get_attribute('class')
         self.selenium.find_element(*self._development_channel_toggle).click()
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.is_element_visible(*self._development_channel_content_locator))
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: expander.get_attribute('class') is not expander_saved_class)
 
     @property
     def is_development_channel_expanded(self):


### PR DESCRIPTION
This addresses the failure as seen at [1]. I guess the markup changed so that now the element that used to be visible is no longer visible, which was causing the wait to time out. Tbh, I'm surprised it worked before, but evidently it did.

[1] http://qa-selenium.mv.mozilla.com:8080/job/amo.dev.mac/198/testReport/junit/tests.desktop.test_details_page/TestDetails/test_that_the_development_channel_expands/
