### PR TITLE
Add a wait for install button to be visible

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -533,7 +533,10 @@ class Details(Base):
 
     @property
     def is_development_channel_install_button_visible(self):
-        return self.is_element_visible(*self._development_channel_install_button_locator)
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: self.is_element_visible(*self._development_channel_install_button_locator),
+            "Timeout waiting for 'development channel install' button.")
+        return True
 
     @property
     def development_channel_content(self):


### PR DESCRIPTION
This should address the failure as seen at http://qa-selenium.mv.mozilla.com:8080/view/AMO/job/amo.dev.mac.saucelabs/155/testReport/tests.desktop.test_details_page/TestDetails/test_the_development_channel_section/
