### PR TITLE
Add maximize_window to deal with button not on screen

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -558,6 +558,7 @@ class Details(Base):
                 "Timeout waiting for 'make contribution' button.")
 
         def click_make_contribution_button(self):
+            self.selenium.maximize_window()
             self.selenium.find_element(*self._make_contribution_button_locator).click()
             from pages.desktop.regions.paypal_frame import PayPalFrame
             return PayPalFrame(self.testsetup)


### PR DESCRIPTION
After much investigation and head scratching and hand wringing, I was able to solve the failures with test_paypal on our grid machines by making sure the window is maximized before trying to click the "Make Contribution" button. This PR just maximizes the window at that point, but I wonder if it would be worthwhile to try to put the maximize somewhere that it would address all tests (in case it's needed elsewhere in the future).  If that's desired I can look into that, or perhaps we can merge this, to address the failures, and open an issue for the more extensive version.

This change was run as an adhoc on prod [1] and dev [2].

[1] http://qa-selenium.mv.mozilla.com:8080/view/AMO/job/amo.prod.testing/5/
[2] http://qa-selenium.mv.mozilla.com:8080/view/AMO/job/amo.dev.testing/1/
