### PR TITLE
Fixing tests that use the search box

### DIFF
--- a/pages/desktop/base.py
+++ b/pages/desktop/base.py
@@ -20,8 +20,6 @@ class Base(Page):
     _amo_logo_link_locator = (By.CSS_SELECTOR, ".site-title a")
     _amo_logo_image_locator = (By.CSS_SELECTOR, ".site-title img")
 
-    _mozilla_logo_link_locator = (By.CSS_SELECTOR, "#global-header-tab a")
-
     _footer_locator = (By.CSS_SELECTOR, "#footer")
 
     def login(self, method="normal", user="default"):
@@ -66,13 +64,6 @@ class Base(Page):
     @property
     def amo_logo_image_source(self):
         return self.selenium.find_element(*self._amo_logo_image_locator).get_attribute('src')
-
-    @property
-    def is_mozilla_logo_visible(self):
-        return self.is_element_visible(*self._mozilla_logo_link_locator)
-
-    def click_mozilla_logo(self):
-        self.selenium.find_element(*self._mozilla_logo_link_locator).click()
 
     def credentials_of_user(self, user):
         return self.parse_yaml_file(self.credentials)[user]
@@ -146,7 +137,7 @@ class Base(Page):
 
         #Search box
         _search_button_locator = (By.CSS_SELECTOR, ".search-button")
-        _search_textbox_locator = (By.NAME, "q")
+        _search_textbox_locator = (By.ID, "search-q")
 
         #Not LoggedIn
         _login_browser_id_locator = (By.CSS_SELECTOR, "a.browserid-login")

--- a/pages/desktop/user.py
+++ b/pages/desktop/user.py
@@ -156,7 +156,7 @@ class EditProfile(Base):
 
 class MyCollections(Base):
 
-    _header_locator = (By.CSS_SELECTOR, "h2")
+    _header_locator = (By.CSS_SELECTOR, ".primary > header > h2")
 
     @property
     def my_collections_header_text(self):

--- a/tests/desktop/test_layout.py
+++ b/tests/desktop/test_layout.py
@@ -55,17 +55,6 @@ class TestAmoLayout:
         Assert.equal(home_page.get_url_current_page(), '%s/en-US/firefox/' % home_page.base_url)
 
     @pytest.mark.nondestructive
-    def test_that_clicking_mozilla_logo_loads_mozilla_dot_org(self, mozwebqa):
-        """
-        Test for Litmus 22922.
-        https://litmus.mozilla.org/show_test.cgi?id=22922
-        """
-        home_page = Home(mozwebqa)
-        Assert.true(home_page.is_mozilla_logo_visible)
-        home_page.click_mozilla_logo()
-        Assert.equal(home_page.get_url_current_page(), "http://www.mozilla.org/en-US/")
-
-    @pytest.mark.nondestructive
     def test_that_other_applications_link_has_tooltip(self, mozwebqa):
         """
         Test for Litmus 22925.


### PR DESCRIPTION
Currently we have 21 tests that fail on dev because the search box
http://qa-selenium.mv.mozilla.com:8080/job/amo.dev/lastCompletedBuild/testReport/
