### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Also see the documentation on [davehunt's pytest-mozwebqa Github project page] [
 [pymozwebqa]: https://github.com/davehunt/pytest-mozwebqa
 
 ####Virtualenv and Virtualenvwrapper (Optional/Intermediate level)
-While most of us have had some experience using virtual machines, [virtualenv][venv] is something else entirely.  It's used to keep libraries that you install from clashing and messing up your local environment.  After installing virtualenv, installing [virtualenvwrapper][wrapper] will give you some nice commands to use with virtualenvwrapper.
+While most of us have had some experience using virtual machines, [virtualenv][venv] is something else entirely.  It's used to keep libraries that you install from clashing and messing up your local environment.  After installing virtualenv, installing [virtualenvwrapper][wrapper] will give you some nice commands to use with virtualenv.
 [venv]: http://pypi.python.org/pypi/virtualenv
 [wrapper]: http://www.doughellmann.com/projects/virtualenvwrapper/
 
-For a more detailed discussion of virtualenv and virtualenvwrapper, check out [our quickstart guide] (https://wiki.mozilla.org/QA/Execution/Web_Testing/Automation/Virtual_Environments) and also [this blog post] (https://wiki.mozilla.org/QA/Execution/Web_Testing/Automation/Virtual_Environments).
+For a more detailed discussion of virtualenv and virtualenvwrapper, check out [our quickstart guide] (https://wiki.mozilla.org/QA/Execution/Web_Testing/Automation/Virtual_Environments) and also [this blog post] (http://www.silverwareconsulting.com/index.cfm/2012/7/24/Getting-Started-with-virtualenv-and-virtualenvwrapper-in-Python).
 
 #### Moz-grid-config (Optional/Intermediate level)
 Prerequisites: [Java Runtime Environment][Java JRE], [Apache Ant][ANT]


### PR DESCRIPTION
This is part of my documentation spike. I wanted to create a reference readme file which we can use to update other files, and this one was the most recently updated. I have also been working on the QMO page at https://quality.mozilla.org/docs/webqa/running-webqa-automated-tests/  to make it relevant for all platforms, which is why I removed the link to https://wiki.mozilla.org/QA_SoftVision_Team/WebQA_Automation  from this doc.

Tbh, I'm not sure whether we want to keep all the detailed instructions for installing software in each of these project readme's, but I didn't want to remove that for now. If we do end up with one really good doc about installing software and configuring the environment then perhaps we can remove all of that from the readme and just point to the new doc. On the other hand, it is very nice for new contributors to see everything in one place, and to not have to jump back and forth between pages.

Feedback/reviews welcome, even from you @davehunt. :)
