### PR TITLE
Fixing CSS selectors and broken 'Categories' test.

### DIFF
--- a/pages/desktop/category.py
+++ b/pages/desktop/category.py
@@ -21,11 +21,12 @@ class Category(Base):
     _categories_language_support_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(7) > a")
     _categories_photo_music_video_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(8) > a")
     _categories_privacy_security_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(9) > a")
-    _categories_shopping_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(10) > a")
-    _categories_social_communication_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(11) > a")
-    _categories_tabs_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(12) > a")
-    _categories_web_development_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(13) > a")
-    _categories_other_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(14) > a")
+    _categories_search_tools_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(10) > a")
+    _categories_shopping_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(11) > a")
+    _categories_social_communication_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(12) > a")
+    _categories_tabs_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(13) > a")
+    _categories_web_development_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(14) > a")
+    _categories_other_link_locator = (By.CSS_SELECTOR, "#side-categories > li:nth-of-type(15) > a")
 
     @property
     def categories_side_navigation_header_text(self):


### PR DESCRIPTION
Adding new categories - "search tools", updating css selectors, fixing a test.

additional info:

root analysis:
self = <class unittestzero.Assert at 0x1b47c80>, first = 'Shopping', second = u'Search Tools', msg = None

```
@classmethod
def equal(self, first, second, msg=None):
    """
        Asserts that 2 elements are the same

        :Args:
         - First object to be tested
         - Second object to be tested
         - Message that will be printed if it fails
        """
```

> ```
>   assert first == second, msg
> ```
> 
> E       AssertionError: None

../../venvs/addons/local/lib/python2.7/site-packages/unittestzero.py:53: AssertionError


after fix:
1) run 
platform linux2 -- Python 2.7.4 -- pytest-2.3.5 -- /home/jakub/venvs/addons/bin/python
plugins: mozwebqa, xdist
collected 22 items 

tests/desktop/test_homepage.py:313: TestHome.test_that_checks_all_categories_side_navigation PASSED

2) run

platform linux2 -- Python 2.7.4 -- pytest-2.3.5
plugins: mozwebqa, xdist
collected 22 items 

tests/desktop/test_homepage.py .....................

 1 tests deselected by "-m 'nondestructive'" 
 21 passed, 1 deselected in 333.78 seconds ==========
