### PR TITLE
Unxfail test_sorting_by_downloads

### DIFF
--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -145,7 +145,6 @@ class TestSearch:
                 Assert.contains(search_term, search_range.lower())
                 details_page.return_to_previous_page()
 
-    @pytest.mark.xfail(reason='Bug 920700 - Sorting by Weekly Downloads produces incorrect sorting')
     @pytest.mark.native
     @pytest.mark.nondestructive
     def test_sorting_by_downloads(self, mozwebqa):


### PR DESCRIPTION
This is now Xpassed on CI and locally
http://qa-selenium.mv.mozilla.com:8080/job/amo.dev/lastCompletedBuild/HTML_Report/?

BUG https://bugzilla.mozilla.org/show_bug.cgi?id=920700
