### PR TITLE
"What's this?" missing from "Memchaser" app under Version Information

### DIFF
--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -350,11 +350,9 @@ class TestDetails:
         details_page = Details(mozwebqa, 'firebug')
         Assert.contains("active", details_page.click_and_hold_install_button_returns_class_value())
 
-    @pytest.mark.xfail("config.getvalue('base_url') == 'https://addons-dev.allizom.org'",
-                       reason="[dev] Whats this? missing from Memchaser app under Version Information")
     @pytest.mark.nondestructive
     def test_what_is_this_in_the_version_information(self, mozwebqa):
-        details_page = Details(mozwebqa, "MemChaser")
+        details_page = Details(mozwebqa, "Firebug")
         Assert.equal(details_page.version_information_heading, "Version Information")
         details_page.expand_version_information()
         Assert.equal("What's this?", details_page.license_faq_text)


### PR DESCRIPTION
We already use Firebug as the default app for all  <code>test_details_page.py</code>
So let's just change the app for this test also and add the coverage. 
