### PR TITLE
Fix "test_the_logout_link_for_logged_in_users" on stage and olympia

### DIFF
--- a/pages/desktop/discovery.py
+++ b/pages/desktop/discovery.py
@@ -36,7 +36,7 @@ class DiscoveryPane(Base):
 
     def __init__(self, testsetup, path):
         Base.__init__(self, testsetup)
-        self.selenium.get(self.api_base_url + path)
+        self.selenium.get(self.base_url + path)
         #resizing this page for elements that disappear when the window is < 1000
         #self.selenium.set_window_size(1000, 1000) Commented because this selenium call is still in beta
 


### PR DESCRIPTION
As you can see in the screencast, the URL changes to DEV when going to Discovery page
https://saucelabs.com/jobs/8436ad9bfea84524b9e374013dd2b9ca

this should not take the api_base_url
