### PR TITLE
This change is for Bug 990999, email value is not written backwards

### DIFF
--- a/pages/desktop/user.py
+++ b/pages/desktop/user.py
@@ -66,8 +66,7 @@ class ViewProfile(Base):
 
     @property
     def email_value(self):
-        email = self.selenium.find_element(*self._email_locator).text
-        return email[::-1]
+        return self.selenium.find_element(*self._email_locator).text
 
 
 class User(Base):


### PR DESCRIPTION
Bug 990999 - [dev] [stage] Email address value is the same as the displayed address

https://bugzilla.mozilla.org/show_bug.cgi?id=990999
