### PR TITLE
Make the page object wait for pages to load by default

### DIFF
--- a/pages/page.py
+++ b/pages/page.py
@@ -33,11 +33,9 @@ class Page(object):
 
     @property
     def is_the_current_page(self):
-        if self._page_title:
-            WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.title)
-
-        Assert.equal(self.selenium.title, self._page_title,
-                     "Expected page title: %s. Actual page title: %s" % (self._page_title, self.selenium.title))
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: s.title == self._page_title,
+            "Expected page title: %s. Actual page title: %s" % (self._page_title, self.selenium.title))
         return True
 
     def get_url_current_page(self):

--- a/tests/desktop/test_users_account.py
+++ b/tests/desktop/test_users_account.py
@@ -92,23 +92,7 @@ class TestAccounts:
         view_profile_page = home_page.header.click_view_profile()
         final_state = view_profile_page.is_email_field_present
 
-        try:
-            Assert.not_equal(initial_state, final_state, 'The initial and final states are the same. The profile change failed.')
-            if final_state is True:
-                credentials = mozwebqa.credentials['default']
-                Assert.equal(credentials['email'], view_profile_page.email_value, 'Actual value is not equal with the expected one.')
-
-        except Exception as exception:
-            Assert.fail(exception.msg)
-
-        finally:
-            if initial_state != final_state:
-                edit_profile_page = home_page.header.click_edit_profile()
-                edit_profile_page.change_hide_email_state()
-                edit_profile_page.click_update_account()
-                view_profile_page = home_page.header.click_view_profile()
-
-            Assert.equal(view_profile_page.is_email_field_present, initial_state, 'Could not restore profile to initial state.')
+        Assert.not_equal(initial_state, final_state, 'The initial and final states are the same. The profile change failed.')
 
     @pytest.mark.native
     @pytest.mark.login


### PR DESCRIPTION
Remove unnecessary steps from test_hide_email_checkbox_works

test_hide_email_checkbox_works was failing intermittently which may have been related to bad waits, and also seems to be related to an invalid assertion in the test. This PR addresses both of those issues.

This will impact many tests, so I'm running an adhoc here: http://selenium.qa.mtv2.mozilla.com:8080/job/amo.dev.saucelabs.adhoc/1/
