### PR TITLE
Update test so that only editable fields are interacted with.

### DIFF
--- a/pages/desktop/user.py
+++ b/pages/desktop/user.py
@@ -7,6 +7,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchAttributeException
 
 from pages.desktop.base import Base
 from pages.page import Page
@@ -142,8 +144,19 @@ class EditProfile(Base):
         def field_value(self):
             try:
                 return self._root_element.find_element(*self._input_field_locator).get_attribute('value')
-            except Exception.NoSuchAttributeException:
-                return " "
+            except NoSuchAttributeException:
+                return ' '
+
+        @property
+        def input_type(self):
+            try:
+                return self._root_element.find_element(*self._input_field_locator).get_attribute('type')
+            except (NoSuchElementException, NoSuchAttributeException):
+                return ' '
+
+        @property
+        def is_field_editable(self):
+            return self.input_type == 'text' or self.input_type == 'url'
 
         @property
         def field_name(self):

--- a/tests/desktop/test_users_account.py
+++ b/tests/desktop/test_users_account.py
@@ -107,15 +107,16 @@ class TestAccounts:
         Assert.true(user_edit_page.is_the_current_page)
 
         # save initial values to restore them after the test is finished
-        fields_no = len(user_edit_page.profile_fields) - 2
+        fields_no = len(user_edit_page.profile_fields)
         initial_value = [None] * fields_no
         random_name = "test%s" % random.randrange(1, 100)
 
         # enter new values
         for i in range(0, fields_no):
-            initial_value[i] = deepcopy(user_edit_page.profile_fields[i].field_value)
-            user_edit_page.profile_fields[i].clear_field()
-            user_edit_page.profile_fields[i].type_value(random_name)
+            if user_edit_page.profile_fields[i].is_field_editable:
+                initial_value[i] = deepcopy(user_edit_page.profile_fields[i].field_value)
+                user_edit_page.profile_fields[i].clear_field()
+                user_edit_page.profile_fields[i].type_value(random_name)
 
         user_edit_page.click_update_account()
         Assert.equal(user_edit_page.update_message, "Profile Updated")
@@ -123,7 +124,8 @@ class TestAccounts:
         # using try finally to ensure that the initial values are restore even if the Asserts fail.
         try:
             for i in range(0, fields_no):
-                Assert.contains(random_name, user_edit_page.profile_fields[i].field_value)
+                if user_edit_page.profile_fields[i].is_field_editable:
+                    Assert.contains(random_name, user_edit_page.profile_fields[i].field_value)
 
         except Exception as exception:
             Assert.fail(exception.msg)
@@ -131,7 +133,8 @@ class TestAccounts:
         finally:
             # restore initial values
             for i in range(0, fields_no):
-                user_edit_page.profile_fields[i].clear_field()
-                user_edit_page.profile_fields[i].type_value(initial_value[i])
+                if user_edit_page.profile_fields[i].is_field_editable:
+                    user_edit_page.profile_fields[i].clear_field()
+                    user_edit_page.profile_fields[i].type_value(initial_value[i])
 
             user_edit_page.click_update_account()


### PR DESCRIPTION
test_user_can_update_profile_information_in_account_settings_page started failing on amo.dev because a new non-editable field was added to the user profile page.

http://selenium.qa.mtv2.mozilla.com:8080/view/All%20not%20B2G/job/amo.dev/1309/HTML_Report/

Updated the test so that it only interacts with editable input fields.
