### PR TITLE
Add explicit wait for height of the promo box on DiscoveryPane page

### DIFF
--- a/pages/desktop/discovery.py
+++ b/pages/desktop/discovery.py
@@ -13,6 +13,7 @@ from pages.desktop.base import Base
 
 class DiscoveryPane(Base):
 
+    _promo_box_locator = (By.ID, 'promos')
     _what_are_addons_text_locator = (By.CSS_SELECTOR, '#intro p')
     _mission_section_text_locator = (By.CSS_SELECTOR, '#mission > p')
     _learn_more_locator = (By.ID, 'learn-more')
@@ -39,6 +40,7 @@ class DiscoveryPane(Base):
         self.selenium.get(self.base_url + path)
         #resizing this page for elements that disappear when the window is < 1000
         #self.selenium.set_window_size(1000, 1000) Commented because this selenium call is still in beta
+        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.find_element(*self._promo_box_locator).size['height'] == 273)
 
     @property
     def what_are_addons_text(self):


### PR DESCRIPTION
test_that_mission_statement_is_on_addons_home_page have failed on addons.dev: http://selenium.qa.mtv2.mozilla.com:8080/view/AMO/job/amo.dev/1363/HTML_Report/
From the screenshot it looks like the DiscoveryPane page was not completely loaded, as the promo box is not displayed. 
I added a wait for the height of the promo box, similar to: https://github.com/mozilla/Addon-Tests/blob/master/pages/desktop/home.py#L52, to make sure the page is ready for testing. 
