### PR TITLE
Fix failing tests due to change in static file path

### DIFF
--- a/tests/desktop/test_layout.py
+++ b/tests/desktop/test_layout.py
@@ -29,7 +29,7 @@ class TestAmoLayout:
         home_page = Home(mozwebqa)
         Assert.equal(home_page.amo_logo_text, "ADD-ONS")
         Assert.equal(home_page.amo_logo_title, "Return to the Firefox Add-ons homepage")
-        Assert.contains("-cdn.allizom.org/media/img/app-icons/med/firefox.png", home_page.amo_logo_image_source)
+        Assert.contains("/img/app-icons/med/firefox.png", home_page.amo_logo_image_source)
 
     @pytest.mark.nondestructive
     def test_that_clicking_the_amo_logo_loads_home_page(self, mozwebqa):

--- a/tests/mobile/test_home.py
+++ b/tests/mobile/test_home.py
@@ -130,7 +130,7 @@ class TestHome:
 
         Assert.equal('Return to the Firefox Add-ons homepage', home.logo_title)
         Assert.equal('ADD-ONS', home.logo_text)
-        Assert.contains('/media/img/zamboni/app_icons/firefox.png', home.logo_image_src)
+        Assert.contains('/img/zamboni/app_icons/firefox.png', home.logo_image_src)
         Assert.equal('Easy ways to personalize.', home.subtitle)
 
     @pytest.mark.nondestructive


### PR DESCRIPTION
I made the paths for the checked images more general such that they are more robust to static path changes such as one recently on dev. The desktop test passes on both dev on stage, but I cannot test the mobile test as of now.
