### PR TITLE
Adjust index used to check image links in test_navigation_buttons_for_image_viewer to be more resistant to static path changes

### DIFF
--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -173,12 +173,11 @@ class TestDetails:
         image_viewer = detail_page.previewer.click_image()
         Assert.true(image_viewer.is_visible)
         Assert.equal(images_count, image_viewer.images_count)
-
         for i in range(image_viewer.images_count):
             Assert.true(image_viewer.is_visible)
 
             Assert.equal(image_viewer.caption, images_title[i])
-            Assert.equal(image_viewer.image_link.split('/')[8], image_link[i].split('/')[8])
+            Assert.equal(image_viewer.image_link.split('/')[-1], image_link[i].split('/')[-1])
 
             if not i == 0:
                 Assert.true(image_viewer.is_previous_present)
@@ -195,7 +194,7 @@ class TestDetails:
             Assert.true(image_viewer.is_visible)
 
             Assert.equal(image_viewer.caption, images_title[i])
-            Assert.equal(image_viewer.image_link.split('/')[8], image_link[i].split('/')[8])
+            Assert.equal(image_viewer.image_link.split('/')[-1], image_link[i].split('/')[-1])
 
             if not i == image_viewer.images_count - 1:
                 Assert.true(image_viewer.is_next_present)


### PR DESCRIPTION
Another failure due to the static path changes. By changing the index used to just be -1, if the prefixed path changes the test can still pass as the index is only dependent on what is at the end of the path and not what is at the beginning. I tested this change on dev, stage, and prod on firefox with no failures.
