### PR TITLE
remove unused import

### DIFF
--- a/tests/desktop/test_statistics.py
+++ b/tests/desktop/test_statistics.py
@@ -4,7 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from urlparse import urlparse
 from datetime import datetime, timedelta
 import json
 


### PR DESCRIPTION
Accidentally let `urlparse` slip in with pr #751 