### PR TITLE
improve failure message

### DIFF
--- a/tests/desktop/test_search.py
+++ b/tests/desktop/test_search.py
@@ -227,7 +227,8 @@ class TestSearch:
             amo_addon_type_page = amo_home_page.header.site_navigation_menu(addon_type).click()
         search_results = amo_addon_type_page.search_for(term)
 
-        Assert.true(search_results.result_count > 0)
+        Assert.true(search_results.result_count > 0,
+                    'Search did not return results. Search terms: %s' % amo_addon_type_page.selenium.current_url)
 
         for i in range(search_results.result_count):
             addon = search_results.result(i).click_result()


### PR DESCRIPTION
In exploring <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1117739">Bug 1117739</a> as well as pr #737 I would like to update the error message to include the url with the GET params.