### PR TITLE
Avoid clicking on themes that are not displayed

### DIFF
--- a/pages/desktop/themes.py
+++ b/pages/desktop/themes.py
@@ -7,8 +7,8 @@
 import re
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 
+from pages.page import PageRegion
 from pages.desktop.base import Base
 from pages.desktop.search import SearchResultList
 
@@ -16,11 +16,10 @@ from pages.desktop.search import SearchResultList
 class Themes(Base):
 
     _page_title = "Themes :: Add-ons for Firefox"
-    _themes_locator = (By.CSS_SELECTOR, 'div.persona.persona-small a')
     _start_exploring_locator = (By.CSS_SELECTOR, "#featured-addons.personas-home a.more-info")
     _featured_addons_locator = (By.CSS_SELECTOR, "#featured-addons.personas-home")
 
-    _featured_themes_locator = (By.CSS_SELECTOR, ".personas-featured .persona.persona-small")
+    _featured_themes_locator = (By.CSS_SELECTOR, '.personas-featured .persona-preview')
     _recently_added_locator = (By.CSS_SELECTOR, "#personas-created .persona-small")
     _most_popular_locator = (By.CSS_SELECTOR, "#personas-popular .persona-small")
     _top_rated_locator = (By.CSS_SELECTOR, "#personas-rating .persona-small")
@@ -28,19 +27,9 @@ class Themes(Base):
     _theme_header_locator = (By.CSS_SELECTOR, ".featured-inner > h2")
 
     @property
-    def theme_count(self):
-        """Returns the total number of theme links in the page."""
-        return len(self.selenium.find_elements(*self._themes_locator))
-
-    def click_theme(self, index):
-        """Clicks on the theme with the given index in the page."""
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: self.selenium.find_elements(*self._themes_locator)[index].is_displayed())
-
-        self.selenium.find_elements(*self._themes_locator)[index].click()
-        theme_detail = ThemesDetail(self.testsetup)
-
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: theme_detail.is_title_visible)
-        return theme_detail
+    def featured_themes(self):
+        return [self.ThemePreview(self.testsetup, root=el) for
+                el in self.selenium.find_elements(*self._featured_themes_locator)]
 
     def open_theme_detail_page(self, theme_key):
         self.selenium.get(self.base_url + "/addon/%s" % theme_key)
@@ -53,10 +42,6 @@ class Themes(Base):
     @property
     def is_featured_addons_present(self):
         return len(self.selenium.find_elements(*self._featured_addons_locator)) > 0
-
-    @property
-    def featured_themes_count(self):
-        return len(self.selenium.find_elements(*self._featured_themes_locator))
 
     @property
     def recently_added_count(self):
@@ -88,6 +73,12 @@ class Themes(Base):
     @property
     def theme_header(self):
         return self.selenium.find_element(*self._theme_header_locator).text
+
+    class ThemePreview(PageRegion):
+
+        def click(self):
+            self.root.click()
+            return ThemesDetail(self.testsetup)
 
 
 class ThemesDetail(Base):

--- a/pages/page.py
+++ b/pages/page.py
@@ -60,3 +60,20 @@ class Page(object):
 
     def return_to_previous_page(self):
         self.selenium.back()
+
+
+class PageRegion(object):
+
+    _root_locator = None
+
+    def __init__(self, testsetup, root=None):
+        self.testsetup = testsetup
+        self.selenium = testsetup.selenium
+        self.timeout = testsetup.timeout
+        self.root_element = root
+
+    @property
+    def root(self):
+        if self.root_element is None and self._root_locator is not None:
+            self.root_element = self.selenium.find_element(*self._root_locator)
+        return self.root_element

--- a/tests/desktop/test_themes.py
+++ b/tests/desktop/test_themes.py
@@ -40,7 +40,7 @@ class TestThemes:
         home_page = Home(mozwebqa)
         themes_page = home_page.header.site_navigation_menu("Themes").click()
         assert themes_page.is_the_current_page
-        assert themes_page.featured_themes_count <= 6
+        assert 0 < len(themes_page.featured_themes) <= 6
 
     @pytest.mark.native
     @pytest.mark.smoke
@@ -83,10 +83,9 @@ class TestThemes:
         themes_page = home_page.header.site_navigation_menu("Themes").click()
         assert themes_page.is_the_current_page
 
-        # Step 3: Click on any theme.
-        random_theme_index = random.randint(1, themes_page.theme_count - 1)
-
-        themes_detail_page = themes_page.click_theme(random_theme_index)
+        # Step 3: Click on any featured theme.
+        theme = random.choice(themes_page.featured_themes)
+        themes_detail_page = theme.click()
         assert themes_detail_page.is_the_current_page
 
         # Verify breadcrumb menu format, i.e. Add-ons for Firefox > themes > {theme Name}.


### PR DESCRIPTION
With Selenium 2.48 the element clicking has become more realistic, which has identified a problem in `test_breadcrumb_menu_in_theme_details_page`. This test clicked a random theme on the page, which would include an animated ticker of themes, so we intermittently picked one of these themes and the click is no longer succeeding. This patch limits the focus of this test to the featured themes. I resisted some obvious cleanup of the other theme previews, but that could be taken care of in a later patch.

Pinging @mozilla/web-qa-apprentices for review.