### PR TITLE
Scroll search results into view before clicking them

### DIFF
--- a/pages/desktop/search.py
+++ b/pages/desktop/search.py
@@ -127,6 +127,8 @@ class SearchResultList(Base):
             return mktime(date)
 
         def click_result(self):
+            # make sure the search result is in view
+            self.selenium.execute_script('arguments[0].scrollIntoView();', self._root_element)
             self._root_element.find_element(*self._name_locator).click()
             from pages.desktop.collections import Collection, CollectionSearchResultList
             from pages.desktop.themes import ThemesDetail, ThemesSearchResultList


### PR DESCRIPTION
It seems that at least on Mac these search results are not scrolled into view before clicking them. It could be that this is caused by us using `find_elements` and that calling `find_element` from another element does not perform the scroll. I was able to replicate the failure locally, and this patch fixed it for me.