### PR TITLE
Only check for the existence of at least one Featured Collection

### DIFF
--- a/tests/desktop/test_homepage.py
+++ b/tests/desktop/test_homepage.py
@@ -92,7 +92,7 @@ class TestHome:
     def test_that_featured_collections_exist_on_the_home(self, base_url, selenium):
         home_page = Home(base_url, selenium)
         assert u'Featured Collections See all \xbb' == home_page.featured_collections_title, 'Featured Collection region title doesn\'t match'
-        assert home_page.featured_collections_count == 4
+        assert home_page.featured_collections_count > 0
 
     @pytest.mark.nondestructive
     def test_that_featured_extensions_exist_on_the_home(self, base_url, selenium):


### PR DESCRIPTION
As per @krupa's response to the fact that `test_that_featured_collections_exist_on_the_home` is failing on stage because there are only 2 collections [1], this changes the logic to only assert that there is at least 1.

[1] https://webqa-ci.mozilla.com/view/AMO/job/amo.stage.saucelabs/736/testReport/junit/tests.desktop.test_homepage/TestHome/test_that_featured_collections_exist_on_the_home/

@mozilla/web-qa-sorcerers r?