### PR TITLE
Fixes #812 - Remove checks for 'Often Used With' section

### DIFF
--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -47,8 +47,6 @@ class Details(Base):
     _source_code_license_information_locator = (By.CSS_SELECTOR, ".source > li > a")
     _reviews_title_locator = (By.CSS_SELECTOR, "#reviews > h2")
     _tags_locator = (By.ID, "tagbox")
-    _other_addons_header_locator = (By.CSS_SELECTOR, "h2.compact-bottom")
-    _other_addons_list_locator = (By.CSS_SELECTOR, ".primary .listing-grid")
     _part_of_collections_header_locator = (By.CSS_SELECTOR, "#collections-grid h2")
     _part_of_collections_list_locator = (By.CSS_SELECTOR, "#collections-grid section li")
     _icon_locator = (By.CSS_SELECTOR, "img.icon")
@@ -223,10 +221,6 @@ class Details(Base):
         return [review.text for review in self.selenium.find_elements(*self._review_details_locator)]
 
     @property
-    def often_used_with_header(self):
-        return self.selenium.find_element(*self._other_addons_header_locator).text
-
-    @property
     def devs_comments_title(self):
         return self.selenium.find_element(*self._devs_comments_title_locator).text
 
@@ -290,10 +284,6 @@ class Details(Base):
         is in view.
         """
         return (self.selenium.execute_script('return window.pageYOffset')) > 1000
-
-    @property
-    def is_often_used_with_list_visible(self):
-        return self.is_element_visible(*self._other_addons_list_locator)
 
     @property
     def are_tags_visible(self):

--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -72,12 +72,6 @@ class TestDetails:
             assert review is not None
 
     @pytest.mark.nondestructive
-    def test_that_in_often_used_with_addons_are_displayed(self, base_url, selenium):
-        details_page = Details(base_url, selenium, "Firebug")
-        assert u'Often used with\u2026' == details_page.often_used_with_header
-        assert details_page.is_often_used_with_list_visible
-
-    @pytest.mark.nondestructive
     def test_that_tags_are_displayed(self, base_url, selenium):
         details_page = Details(base_url, selenium, "Firebug")
         assert details_page.are_tags_visible


### PR DESCRIPTION
Remove test_that_in_often_used_with_addons_are_displayed and associated page objects

Adhoc running at http://webqa-ci-staging1.qa.scl3.mozilla.com:8080/job/amo.adhoc/11/

@mozilla/web-qa-sorcerers r?