### PR TITLE
Change timezone for review test to UTC

### DIFF
--- a/tests/desktop/test_reviews.py
+++ b/tests/desktop/test_reviews.py
@@ -46,7 +46,6 @@ class TestReviews:
         assert page_number + 1 == view_reviews.paginator.page_number
 
     @pytest.mark.native
-    @pytest.mark.xfail(reason='https://github.com/mozilla/Addon-Tests/issues/821')
     def test_that_new_review_is_saved(self, base_url, selenium, logged_in, user):
         details_page = Details(base_url, selenium, 'Memchaser')
         write_review_block = details_page.click_to_write_review()
@@ -61,7 +60,7 @@ class TestReviews:
         review = review_page.reviews[0]
         assert 1 == review.rating
         assert user['display_name'] == review.author
-        date = datetime.now(timezone('US/Pacific')).strftime("%B %d, %Y")
+        date = datetime.now(timezone('UTC')).strftime('%B %d, %Y')
         # there are no leading zero-signs on day so we need to remove them too
         expected_date = date.replace(' 0', ' ')
         assert expected_date == review.date, 'Date of review does not match the expected value.'


### PR DESCRIPTION
This changes the timezone to UTC, which according to #821 should match the timezone of the server. Note that this test still fails on dev because of another issue first noticed in #823 but as far as I can tell this has not been raised.

@krupa @stephendonner r?