### PR TITLE
Fix themes tests after redesign

### DIFF
--- a/pages/desktop/themes.py
+++ b/pages/desktop/themes.py
@@ -14,67 +14,36 @@ from pages.desktop.search import SearchResultList
 class Themes(Base):
 
     _url = '{base_url}/{locale}/firefox/themes/'
-
     _page_title = "Themes :: Add-ons for Firefox"
-    _start_exploring_locator = (By.CSS_SELECTOR, "#featured-addons.personas-home a.more-info")
-    _featured_addons_locator = (By.CSS_SELECTOR, "#featured-addons.personas-home")
 
-    _featured_themes_locator = (By.CSS_SELECTOR, '.personas-featured .persona-preview')
-    _recently_added_locator = (By.CSS_SELECTOR, "#personas-created .persona-small")
-    _most_popular_locator = (By.CSS_SELECTOR, "#personas-popular .persona-small")
-    _top_rated_locator = (By.CSS_SELECTOR, "#personas-rating .persona-small")
+    _featured_themes_locator = (By.CSS_SELECTOR, '.personas-featured .persona')
+    _recently_added_themes_locator = (By.CSS_SELECTOR, "#personas-created .persona")
+    _most_popular_themes_locator = (By.CSS_SELECTOR, "#personas-popular .persona")
+    _top_rated_themes_locator = (By.CSS_SELECTOR, "#personas-rating .persona")
 
     _theme_header_locator = (By.CSS_SELECTOR, ".featured-inner > h2")
 
     @property
     def featured_themes(self):
-        return [self.ThemePreview(self.base_url, self.selenium, root=el) for
+        return [self.Theme(self.base_url, self.selenium, root=el) for
                 el in self.selenium.find_elements(*self._featured_themes_locator)]
 
-    def open_theme_detail_page(self, theme_key):
-        self.selenium.get(self.base_url + "/addon/%s" % theme_key)
-        return ThemesDetail(self.base_url, self.selenium)
-
-    def click_start_exploring(self):
-        self.selenium.find_element(*self._start_exploring_locator).click()
-        return ThemesBrowse(self.base_url, self.selenium)
+    @property
+    def recently_added_themes(self):
+        return [self.Theme(self.base_url, self.selenium, root=el) for
+                el in self.selenium.find_elements(*self._recently_added_themes_locator)]
 
     @property
-    def is_featured_addons_present(self):
-        return len(self.selenium.find_elements(*self._featured_addons_locator)) > 0
+    def most_popular_themes(self):
+        return [self.Theme(self.base_url, self.selenium, root=el) for
+                el in self.selenium.find_elements(*self._most_popular_themes_locator)]
 
     @property
-    def recently_added_count(self):
-        return len(self.selenium.find_elements(*self._recently_added_locator))
+    def top_rated_themes(self):
+        return [self.Theme(self.base_url, self.selenium, root=el) for
+                el in self.selenium.find_elements(*self._top_rated_themes_locator)]
 
-    @property
-    def recently_added_dates(self):
-        iso_dates = self._extract_iso_dates("Added %B %d, %Y", *self._recently_added_locator)
-        return iso_dates
-
-    @property
-    def most_popular_count(self):
-        return len(self.selenium.find_elements(*self._most_popular_locator))
-
-    @property
-    def most_popular_downloads(self):
-        pattern = "(\d+(?:[,]\d+)*)\s+users"
-        return self._extract_integers(pattern, *self._most_popular_locator)
-
-    @property
-    def top_rated_count(self):
-        return len(self.selenium.find_elements(*self._top_rated_locator))
-
-    @property
-    def top_rated_ratings(self):
-        pattern = "Rated\s+(\d)\s+.*"
-        return self._extract_integers(pattern, *self._top_rated_locator)
-
-    @property
-    def theme_header(self):
-        return self.selenium.find_element(*self._theme_header_locator).text
-
-    class ThemePreview(PageRegion):
+    class Theme(PageRegion):
 
         _link_locator = (By.TAG_NAME, 'a')
 
@@ -105,31 +74,8 @@ class ThemesDetail(Base):
         return self.selenium.find_element(*self._themes_title_locator).text
 
 
-class ThemesBrowse(Base):
-
-    _selected_sort_by_locator = (By.CSS_SELECTOR, '#addon-list-options li.selected a')
-    _themes_grid_locator = (By.CSS_SELECTOR, '.featured.listing ul.personas-grid')
-
-    @property
-    def is_the_current_page(self):
-        # This overrides the method in the Page super class.
-        assert self.is_element_present(*self._themes_grid_locator), 'Expected the current page to be the themes browse page.'
-        return True
-
-    @property
-    def sort_key(self):
-        """Returns the current value of the sort request parameter."""
-        url = self.selenium.current_url
-        return re.search("[/][?]sort=(.+)[&]?", url).group(1)
-
-    @property
-    def sort_by(self):
-        """Returns the label of the currently selected sort option."""
-        return self.selenium.find_element(*self._selected_sort_by_locator).text
-
-
 class ThemesSearchResultList(SearchResultList):
-    _results_locator = (By.CSS_SELECTOR, 'ul.personas-grid div.persona-small')
+    _results_locator = (By.CSS_SELECTOR, '.personas-grid .persona')
 
     class ThemesSearchResultItem(SearchResultList.SearchResultItem):
         _name_locator = (By.CSS_SELECTOR, 'h6 > a')

--- a/tests/desktop/test_homepage.py
+++ b/tests/desktop/test_homepage.py
@@ -69,9 +69,8 @@ class TestHome:
     @pytest.mark.nondestructive
     def test_that_clicking_see_all_themes_link_works(self, base_url, selenium):
         home_page = Home(base_url, selenium)
-        featured_theme_page = home_page.click_featured_themes_see_all_link()
-        assert featured_theme_page.is_the_current_page
-        assert 'Themes' == featured_theme_page.theme_header
+        theme_page = home_page.click_featured_themes_see_all_link()
+        assert theme_page.is_the_current_page
 
     @pytest.mark.native
     @pytest.mark.nondestructive

--- a/tests/desktop/test_themes.py
+++ b/tests/desktop/test_themes.py
@@ -5,68 +5,38 @@
 
 import pytest
 
-
 from pages.desktop.home import Home
+from pages.desktop.themes import Themes
 
 
 class TestThemes:
 
     @pytest.mark.native
     @pytest.mark.nondestructive
-    def test_start_exploring_link_in_the_promo_box(self, base_url, selenium):
-        home_page = Home(base_url, selenium)
-        themes_page = home_page.header.site_navigation_menu("Themes").click()
-        assert themes_page.is_the_current_page
-        assert themes_page.is_featured_addons_present
-        browse_themes_page = themes_page.click_start_exploring()
-        assert browse_themes_page.is_the_current_page
-        assert 'up-and-coming' == browse_themes_page.sort_key
-        assert 'Up & Coming' == browse_themes_page.sort_by
-
-    @pytest.mark.native
-    @pytest.mark.nondestructive
     def test_page_title_for_themes_landing_page(self, base_url, selenium):
         home_page = Home(base_url, selenium)
-        themes_page = home_page.header.site_navigation_menu("Themes").click()
+        themes_page = home_page.header.site_navigation_menu('Themes').click()
         assert themes_page.is_the_current_page
 
-    @pytest.mark.native
     @pytest.mark.smoke
     @pytest.mark.nondestructive
     def test_the_featured_themes_section(self, base_url, selenium):
-        home_page = Home(base_url, selenium)
-        themes_page = home_page.header.site_navigation_menu("Themes").click()
-        assert themes_page.is_the_current_page
-        assert 0 < len(themes_page.featured_themes) <= 6
+        page = Themes(base_url, selenium).open()
+        assert 0 < len(page.featured_themes) <= 6
 
-    @pytest.mark.native
     @pytest.mark.smoke
     @pytest.mark.nondestructive
     def test_the_recently_added_section(self, base_url, selenium):
-        home_page = Home(base_url, selenium)
-        themes_page = home_page.header.site_navigation_menu("Themes").click()
-        assert themes_page.is_the_current_page
-        assert 6 == themes_page.recently_added_count
-        recently_added_dates = themes_page.recently_added_dates
-        assert sorted(recently_added_dates, reverse=True) == recently_added_dates
+        page = Themes(base_url, selenium).open()
+        assert 6 == len(page.recently_added_themes)
 
-    @pytest.mark.native
     @pytest.mark.smoke
     @pytest.mark.nondestructive
     def test_the_most_popular_section(self, base_url, selenium):
-        home_page = Home(base_url, selenium)
-        themes_page = home_page.header.site_navigation_menu("Themes").click()
-        assert themes_page.is_the_current_page
-        assert 6 == themes_page.most_popular_count
-        downloads = themes_page.most_popular_downloads
-        assert sorted(downloads, reverse=True) == downloads
+        page = Themes(base_url, selenium).open()
+        assert 6 == len(page.most_popular_themes)
 
-    @pytest.mark.native
     @pytest.mark.nondestructive
     def test_the_top_rated_section(self, base_url, selenium):
-        home_page = Home(base_url, selenium)
-        themes_page = home_page.header.site_navigation_menu("Themes").click()
-        assert themes_page.is_the_current_page
-        assert 6 == themes_page.top_rated_count
-        ratings = themes_page.top_rated_ratings
-        assert sorted(ratings, reverse=True) == ratings
+        page = Themes(base_url, selenium).open()
+        assert 6 == len(page.top_rated_themes)


### PR DESCRIPTION
This fixes several Themes tests after the recent redesign, but is based on a number of assumptions that would need to be confirmed:
- [x] The date is no longer intended to be displayed for recently added themes
- [x] The number of downloads is no longer intended to be displayed for most popular themes
- [x] The rating is no longer intended to be displayed for top rated themes
- [x] The 'start exploring' link has been removed from the themes page
- [x] The theme header 'Themes' has been removed from the themes page

@tofumatt could you comment/confirm the above assumptions? I'd also appreciate if you could look over the changes in this patch, which should reduce our UI test failures by ~6.

@stephendonner could you review the code changes in this patch? Feel free to wait for @tofumatt's feedback.
