### PR TITLE
Mark test_that_new_review_is_saved as expected to fail

### DIFF
--- a/tests/desktop/test_reviews.py
+++ b/tests/desktop/test_reviews.py
@@ -46,6 +46,9 @@ class TestReviews:
         assert page_number + 1 == view_reviews.paginator.page_number
 
     @pytest.mark.native
+    @pytest.mark.xfail(
+        'addons-dev' in pytest.config.getvalue('base_url'),
+        reason='https://github.com/mozilla/addons-server/issues/2442')
     def test_that_new_review_is_saved(self, base_url, selenium, logged_in, user):
         details_page = Details(base_url, selenium, 'Memchaser')
         write_review_block = details_page.click_to_write_review()


### PR DESCRIPTION
Due to https://github.com/mozilla/addons-server/issues/2442
