### PR TITLE
Switch to using Firefox Accounts directly

### DIFF
--- a/pages/desktop/submit.py
+++ b/pages/desktop/submit.py
@@ -14,7 +14,6 @@ class Submit(Base):
     _upload_progress_bar_success_locator = (By.CSS_SELECTOR, "#upload-file>.upload-status>.bar-success")
     _misc_category_locator = (By.CSS_SELECTOR, ".addon-misc-category.checkbox-choices>li>label")
     _mpl_license_locator = (By.CSS_SELECTOR, "#id_builtin>li>label")
-    _review_button_locator = (By.CSS_SELECTOR, ".submit-buttons>button")
     _done_next_steps_locator = (By.CSS_SELECTOR, ".done-next-steps")
     _continue_to_step_3_locator = (By.ID, "submit-upload-file-finish")
     _continue_to_step_4_locator = (By.CSS_SELECTOR, ".submission-buttons.addon-submission-field>button")
@@ -42,9 +41,6 @@ class Submit(Base):
 
     def click_mpl_license(self):
         self.selenium.find_element(*self._mpl_license_locator).click()
-
-    def click_review_button(self):
-        self.selenium.find_element(*self._review_button_locator).click()
 
     def continue_to_step_three(self):
         self.selenium.find_element(*self._continue_to_step_3_locator).click()

--- a/pages/desktop/submit.py
+++ b/pages/desktop/submit.py
@@ -9,6 +9,7 @@ from pages.desktop.base import Base
 
 class Submit(Base):
 
+    _accept_agreement_locator = (By.ID, 'accept-agreement')
     _upload_addon_locator = (By.ID, "upload-addon")
     _upload_progress_bar_success_locator = (By.CSS_SELECTOR, "#upload-file>.upload-status>.bar-success")
     _misc_category_locator = (By.CSS_SELECTOR, ".addon-misc-category.checkbox-choices>li>label")
@@ -27,6 +28,9 @@ class Submit(Base):
     @property
     def is_next_steps_present(self):
         return self.selenium.find_element(*self._done_next_steps_locator).is_displayed()
+
+    def accept_agreement(self):
+        self.selenium.find_element(*self._accept_agreement_locator).click()
 
     def upload_addon(self, path):
         file_selector = self.selenium.find_element(*self._upload_addon_locator)

--- a/pages/desktop/user.py
+++ b/pages/desktop/user.py
@@ -21,12 +21,8 @@ class Login(Base):
     _continue_button_locator = (By.CSS_SELECTOR, '#normal-login .login-source-button')
 
     def login(self, email, password):
-        self.selenium.find_element(*self._email_locator).send_keys(email)
-        self.selenium.find_element(*self._continue_button_locator).click()
         from fxapom.pages.sign_in import SignIn
-        sign_in = SignIn(self.selenium)
-        sign_in.login_password = password
-        sign_in.click_sign_in()
+        SignIn(self.selenium).sign_in(email, password)
 
 
 class ViewProfile(Base):

--- a/tests/desktop/test_extensions.py
+++ b/tests/desktop/test_extensions.py
@@ -14,6 +14,7 @@ class TestExtensions:
         home_page.login(user['email'], user['password'])
 
         submit_page = home_page.header.click_submit_a_new_addon()
+        submit_page.accept_agreement()
 
         path = generate()
         submit_page.upload_addon(path)

--- a/tests/desktop/test_extensions.py
+++ b/tests/desktop/test_extensions.py
@@ -25,7 +25,6 @@ class TestExtensions:
         submit_page.continue_to_step_five()
         submit_page.click_mpl_license()
         submit_page.continue_to_step_six()
-        submit_page.click_review_button()
 
         assert submit_page.is_next_steps_present
 


### PR DESCRIPTION
Now that AMO is no longer offering a intermediate page for account migration to Firefox Accounts we can just go ahead and sign in directly. This fixes the failures on staging. @krupa r?