### PR TITLE
Mark test_that_user_can_make_a_contribution_without_logging_into_amo as flaky

### DIFF
--- a/tests/desktop/test_paypal.py
+++ b/tests/desktop/test_paypal.py
@@ -27,6 +27,7 @@ class TestPaypal:
         payment_popup.close_paypal_popup()
         assert addon_page.is_the_current_page
 
+    @pytest.mark.flaky(reruns=1)
     def test_that_user_can_make_a_contribution_without_logging_into_amo(self, base_url, selenium, paypal_user):
         """Test that checks if the user is able to make a contribution without logging in to AMO."""
         addon_page = Details(base_url, selenium, self.addon_name)

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     fxapom==1.9.1
     pyjwt==1.4.2
     pytest~=3.0.0
+    pytest-rerunfailures==2.1.0
     pytest-selenium
     pytest-variables
     pytest-xdist==1.15.0


### PR DESCRIPTION
This will rerun the flaky test once, and only report a failure if it fails twice in a row. @krupa r?