### PR TITLE
Remove test for viewing add-on source code.

### DIFF
--- a/pages/desktop/addons_site.py
+++ b/pages/desktop/addons_site.py
@@ -110,12 +110,3 @@ class UserFAQ(Base):
     @property
     def license_answer(self):
         return self.selenium.find_element(*self._license_answer_locator).text
-
-
-class ViewAddonSource(Base):
-
-    _file_viewer_locator = (By.ID, 'file-viewer')
-
-    @property
-    def is_file_viewer_visible(self):
-        return self.is_element_visible(*self._file_viewer_locator)

--- a/pages/desktop/details.py
+++ b/pages/desktop/details.py
@@ -28,7 +28,6 @@ class Details(Base):
     _rating_locator = (By.CSS_SELECTOR, "span.stars.large")
     _license_link_locator = (By.CSS_SELECTOR, ".source-license > a")
     _whats_this_license_locator = (By.CSS_SELECTOR, "a.license-faq")
-    _view_the_source_locator = (By.CSS_SELECTOR, "a.source-code")
     _complete_version_history_locator = (By.CSS_SELECTOR, "p.more > a")
     _description_locator = (By.CSS_SELECTOR, "div.prose")
     _other_applications_locator = (By.ID, "other-apps")
@@ -233,21 +232,6 @@ class Details(Base):
     @property
     def is_source_code_license_information_visible(self):
         return self.is_element_visible(*self._source_code_license_information_locator)
-
-    @property
-    def is_view_the_source_link_visible(self):
-        return self.is_element_visible(*self._view_the_source_locator)
-
-    def click_view_source_code(self):
-        self.selenium.find_element(*self._view_the_source_locator).click()
-        from pages.desktop.addons_site import ViewAddonSource
-        addon_source = ViewAddonSource(self.base_url, self.selenium)
-        WebDriverWait(self.selenium, self.timeout).until(lambda s: addon_source.is_file_viewer_visible)
-        return addon_source
-
-    @property
-    def view_source_code_text(self):
-        return self.selenium.find_element(*self._view_the_source_locator).text
 
     @property
     def is_complete_version_history_visible(self):

--- a/tests/desktop/test_details_page.py
+++ b/tests/desktop/test_details_page.py
@@ -238,13 +238,3 @@ class TestDetails:
         assert 'What\'s this?' == details_page.license_faq_text
         license_faq = details_page.click_whats_this_license()
         assert 'Frequently Asked Questions' == license_faq.header_text
-
-    @pytest.mark.nondestructive
-    @pytest.mark.xfail(reason='https://github.com/mozilla/addons-server/issues/5135')
-    def test_view_the_source_in_the_version_information(self, base_url, selenium):
-        details_page = Details(base_url, selenium, "Firebug")
-        assert 'Version Information' == details_page.version_information_heading
-        details_page.expand_version_information()
-        assert 'View the source' == details_page.view_source_code_text
-        view_source = details_page.click_view_source_code()
-        assert '/files/browse/' in view_source.get_url_current_page()


### PR DESCRIPTION
As detailed in https://github.com/mozilla/addons-server/issues/5135 the view source feature was disabled due to performance issues. It looks unlikely to be reintroduced, and as we are intending to retire this repository once sufficient tests are moved to the addons-server repository, it makes sense to remove this test.